### PR TITLE
Fix prepareNotification data merging

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -188,9 +188,9 @@ class Logger extends AbstractApiClient implements LoggerInterface
         $params += array('reported_at' => new \DateTime());
         $params += array('server' => $this->getServerName());
 
-        $data += $params;
+        $mergedData = array_merge($data, $params);
 
-        $notification->hydrate($data);
+        $notification->hydrate($mergedData);
 
         return $notification;
     }


### PR DESCRIPTION
Currently prepareNotification use the array concatenation operator. 
By using this operator, we can't override the initial notification data with the params. 
So for example, the PSR3 adapter does not work well, when we want to send an error it's an info.
We can fix it by using the array_merge function.